### PR TITLE
Make the ajax call native JS. No jQuery dependency.

### DIFF
--- a/assets/js/ajax.js
+++ b/assets/js/ajax.js
@@ -1,18 +1,21 @@
-jQuery(document).ready(function ($) {
-    if( $('body').hasClass('archive')){
-        return;
-    }
-    $.ajax({
-        url: wp_post_views_ajax_object.ajaxurl, // this is the object instantiated in wp_localize_script function
-        type: 'POST',
-        data: {
-            action: 'wppv_counter', // this is the function in your functions.php that will be triggered
-            post_id: wp_post_views_ajax_object.post_id,
-            nonce: wp_post_views_ajax_object.nonce,
-        },
-        success: function (data) {
+document.addEventListener('DOMContentLoaded', function () {
+    if (false == document.body.classList.contains("archive")) {
+        // Get price info with ajax
+        let url = wp_post_views_ajax_object.ajaxurl; // this is the object instantiated in wp_localize_script function);
+
+        let data = new FormData();
+        data.append('action', 'wppv_counter');
+        data.append('post_id', 'custom_art');
+        data.append('nonce', wp_post_views_ajax_object.nonce);
+        
+        let xhttp = new XMLHttpRequest();
+        xhttp.onload = function() {
+            let res = JSON.parse(this.responseText);
             //Do something with the result from server
-            // console.log(data);
+            // console.log(res);
         }
-    });
+
+        xhttp.open("POST", url);
+        xhttp.send(data);
+    }
 });

--- a/assets/js/ajax.js
+++ b/assets/js/ajax.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
     if (false == document.body.classList.contains("archive")) {
-        let url = wp_post_views_ajax_object.ajaxurl; // this is the object instantiated in wp_localize_script function);
+        let url = wp_post_views_ajax_object.ajaxurl;
 
         let data = new FormData();
         data.append('action', 'wppv_counter');
@@ -10,8 +10,6 @@ document.addEventListener('DOMContentLoaded', function () {
         let xhttp = new XMLHttpRequest();
         xhttp.onload = function() {
             let res = JSON.parse(this.responseText);
-            //Do something with the result from server
-            // console.log(res);
         }
 
         xhttp.open("POST", url);

--- a/assets/js/ajax.js
+++ b/assets/js/ajax.js
@@ -1,11 +1,10 @@
 document.addEventListener('DOMContentLoaded', function () {
     if (false == document.body.classList.contains("archive")) {
-        // Get price info with ajax
         let url = wp_post_views_ajax_object.ajaxurl; // this is the object instantiated in wp_localize_script function);
 
         let data = new FormData();
         data.append('action', 'wppv_counter');
-        data.append('post_id', 'custom_art');
+        data.append('post_id', p_post_views_ajax_object.post_id);
         data.append('nonce', wp_post_views_ajax_object.nonce);
         
         let xhttp = new XMLHttpRequest();

--- a/includes/counter.php
+++ b/includes/counter.php
@@ -191,8 +191,8 @@ class WP_Post_Views_Counter_Functions {
         wp_register_script(
             'wp-posts-view-script',
             WP_POST_VIEW_URL.'/assets/js/ajax.js',
-            array('jquery'),
-            false,
+            array(),
+            '1.1',
             true
         );
         wp_enqueue_script('wp-posts-view-script');


### PR DESCRIPTION
I like the plugin. Great work, but I don't think we need jQuery for one simple ajax request. Keeping it lighweight for websites that can run without a jQuery dependency.